### PR TITLE
replacing double quotes with back ticks and apostrophes

### DIFF
--- a/Latex/tests.tex
+++ b/Latex/tests.tex
@@ -108,11 +108,11 @@ The main objective is to observe how the J/S signal affect the availability of P
 
 \subsection*{Test description}
 
-All tests will be performed with the jammers place 1 to 1.5 meters above ground (like on top of a vehicle) or on a stand. Unless otherwise stated, jammers will be in "maximum" posistion, meaning all relevant antennas are switched on and power is set to as high as possible. Runtime and pauses between tests is set in the transmission plan document.
+All tests will be performed with the jammers place 1 to 1.5 meters above ground (like on top of a vehicle) or on a stand. Unless otherwise stated, jammers will be in ``maximum'' posistion, meaning all relevant antennas are switched on and power is set to as high as possible. Runtime and pauses between tests is set in the transmission plan document.
 
 \subsection*{Additional information}
 
-Specification of jammers can be found in Appendix G. Jammer power levels are based on 2023/2024 measurements. "Test bands/constellation" refers to potentially afflicted signal types of the 4 GNSS constellations GPS, GLONASS, Galileo, and BeiDou, from the jammer in question. This information must be considered indicative only. The main principle for putting a signal type in the "Test bands/constellation" list for a given jammer or test, is that measurements done by NKOM indicate that the output signal of the jammer covers the center frequency of the given GNSS band(s).
+Specification of jammers can be found in Appendix G. Jammer power levels are based on 2023/2024 measurements. ``Test bands/constellation'' refers to potentially afflicted signal types of the 4 GNSS constellations GPS, GLONASS, Galileo, and BeiDou, from the jammer in question. This information must be considered indicative only. The main principle for putting a signal type in the ``Test bands/constellation'' list for a given jammer or test, is that measurements done by NKOM indicate that the output signal of the jammer covers the center frequency of the given GNSS band(s).
 
 \section*{Tests within this test group}
 
@@ -398,7 +398,7 @@ The use of continuous high-power jamming will block GNSS signals in a large area
 
 \subsection*{Additional information}
 
-The jammer employed will be F8.1 "Porcus Major", see Appendix G.
+The jammer employed will be F8.1 ``Porcus Major'', see Appendix G.
 
 \section*{Tests within this test group}
 
@@ -450,7 +450,7 @@ Continuous high-power jamming will block GNSS signals in a large area at the eve
 
 \subsection*{Additional information}
 
-The jammer employed will be F8.1 "Porcus Major", see Appendix G.
+The jammer employed will be F8.1 ``Porcus Major'', see Appendix G.
 
 \section*{Tests within this test group}
 
@@ -538,7 +538,7 @@ Continuous high-power jamming will block GNSS signals in a large area at the eve
 
 \subsection*{Additional information}
 
-The jammer employed will be F8.1 "Porcus Major", see Appendix G.
+The jammer employed will be F8.1 ``Porcus Major'', see Appendix G.
 
 \section*{Tests within this test group}
 
@@ -578,7 +578,7 @@ Min: 1 W\\Max: 50 W\subsubsection*{Test bands/constellation}
 'L1', 'E1', 'B1C', 'G1', 'L2', 'L5', 'E5a', 'B2a'
 \subsubsection*{Transmitter equipment}
 'F8.1'
-\\\section{1.5: Continuous stationary high-power jamming with "real world" PRN}
+\\\section{1.5: Continuous stationary high-power jamming with ``real world'' PRN}
 
 \subsection*{Rationale}
 
@@ -590,7 +590,7 @@ The tests will be performed with BPSK modulation with a pseudo random symbol rat
 
 \subsection*{Additional information}
 
-The jammer employed will be F8.1 "Porcus Major", see Appendix G.
+The jammer employed will be F8.1 ``Porcus Major'', see Appendix G.
 
 \section*{Tests within this test group}
 
@@ -624,7 +624,7 @@ The transmitted power will be ramped up and down from a lower to a higher ERP fo
 
 \subsection*{Additional information}
 
-The jammer employed will be F8.1 "Porcus Major", see Appendix G.
+The jammer employed will be F8.1 ``Porcus Major'', see Appendix G.
 
 \section*{Tests within this test group}
 
@@ -676,7 +676,7 @@ The transmitted power will be ramped up and down from a lower to a higher ERP fo
 
 \subsection*{Additional information}
 
-The jammer employed will be F8.1 "Porcus Major", see Appendix G.
+The jammer employed will be F8.1 ``Porcus Major'', see Appendix G.
 
 \section*{Tests within this test group}
 
@@ -720,15 +720,15 @@ Min: 2e-07 W\\Max: 50 W\subsubsection*{Test bands/constellation}
 
 \subsection*{Rationale}
 
-This "pyramid" is intended to test the potential fallback behaviour of modern multi-constellation, multi-frequency receivers.
+This ``pyramid'' is intended to test the potential fallback behaviour of modern multi-constellation, multi-frequency receivers.
 
 \subsection*{Test description}
 
-A jamming pyramid test of GNSS bands. The jamming is performed with PRN modulation and a constant power level. Each pyramid step will lastfor 5 minutes, with first 3 minutes active jamming, and then two minutes off. The test will jam most GNSS bands, incrementally adding bands ("pyramid steps") to the list of jammed signals, then removing them in the reverse order.
+A jamming pyramid test of GNSS bands. The jamming is performed with PRN modulation and a constant power level. Each pyramid step will lastfor 5 minutes, with first 3 minutes active jamming, and then two minutes off. The test will jam most GNSS bands, incrementally adding bands (``pyramid steps'') to the list of jammed signals, then removing them in the reverse order.
 
 \subsection*{Additional information}
 
-The jammer employed will be F8.1 "Porcus Major", see Appendix G.
+The jammer employed will be F8.1 ``Porcus Major'', see Appendix G.
 
 \section*{Tests within this test group}
 
@@ -779,11 +779,11 @@ This ‘inverted pyramid’ is intended to test the potential fallback behaviour
 
 \subsection*{Test description}
 
-An inverted jamming pyramid test of GNSS bands. The jamming is performed with PRN modulation and a constant power level. Each pyramid step will lastfor 5 minutes, with first 3 minutes active jamming, and then two minutes off. The tests will jam most GNSS bands, incrementally removing bands ("pyramid steps") from the list of jammed signals, then adding them in the reverse order.
+An inverted jamming pyramid test of GNSS bands. The jamming is performed with PRN modulation and a constant power level. Each pyramid step will lastfor 5 minutes, with first 3 minutes active jamming, and then two minutes off. The tests will jam most GNSS bands, incrementally removing bands (``pyramid steps'') from the list of jammed signals, then adding them in the reverse order.
 
 \subsection*{Additional information}
 
-The jammer employed will be F8.1 "Porcus Major", see Appendix G.
+The jammer employed will be F8.1 ``Porcus Major'', see Appendix G.
 
 \section*{Tests within this test group}
 
@@ -838,7 +838,7 @@ Jammers used in these tests are commercially available jammers. The jammers are 
 
 \subsection*{Additional information}
 
-Specification of jammers can be found in Appendix G. Jammer power levels are based on 2023/2024 measurements. "Test bands/constellation" refers to potentially afflicted signal types of the 4 GNSS constellations GPS, GLONASS, Galileo, and BeiDou, from the jammer in question. This information must be considered indicative only. The main principle for putting a signal type in the "Test bands/constellation" list for a given jammer or test, is that measurements done by NKOM indicate that the output signal of the jammer covers the center frequency of the given GNSS band(s).
+Specification of jammers can be found in Appendix G. Jammer power levels are based on 2023/2024 measurements. ``Test bands/constellation'' refers to potentially afflicted signal types of the 4 GNSS constellations GPS, GLONASS, Galileo, and BeiDou, from the jammer in question. This information must be considered indicative only. The main principle for putting a signal type in the ``Test bands/constellation'' list for a given jammer or test, is that measurements done by NKOM indicate that the output signal of the jammer covers the center frequency of the given GNSS band(s).
 
 \section*{Tests within this test group}
 
@@ -890,7 +890,7 @@ Jammers used in these tests are commercially available jammers and will be place
 
 \subsection*{Additional information}
 
-Specification of jammers can be found in Appendix G. Jammer power levels are based on 2023/2024 measurements. "Test bands/constellation" refers to potentially afflicted signal types of the 4 GNSS constellations GPS, GLONASS, Galileo, and BeiDou, from the jammer in question. This information must be considered indicative only. The main principle for putting a signal type in the "Test bands/constellation" list for a given jammer or test, is that measurements done by NKOM indicate that the output signal of the jammer covers the center frequency of the given GNSS band(s).
+Specification of jammers can be found in Appendix G. Jammer power levels are based on 2023/2024 measurements. ``Test bands/constellation'' refers to potentially afflicted signal types of the 4 GNSS constellations GPS, GLONASS, Galileo, and BeiDou, from the jammer in question. This information must be considered indicative only. The main principle for putting a signal type in the ``Test bands/constellation'' list for a given jammer or test, is that measurements done by NKOM indicate that the output signal of the jammer covers the center frequency of the given GNSS band(s).
 
 \section*{Tests within this test group}
 
@@ -1015,7 +1015,7 @@ Min: 0.0316 W\\Max: 0.631 W\subsubsection*{Test bands/constellation}
 
 \subsection*{Rationale}
 
-The main objective is to simulate meeting several "more dangerous" jammers, multi-band jammers.
+The main objective is to simulate meeting several ``more dangerous'' jammers, multi-band jammers.
 
 \subsection*{Test description}
 
@@ -1024,7 +1024,7 @@ The test will use three multiband jammers, spaced out in the terrain in differen
 \subsection*{Additional information}
 
 The precise positions for each jammer will have to be decided in field, to best accommodate participants wishes and practical concerns (like terrain). The coordinates for each position, X, Y and Z, will have to be written down in field to help later analysis of the test results.
-Specification of jammers can be found in Appendix G. Jammer power levels are based on 2023/2024 measurements. "Test bands/constellation" refers to potentially afflicted signal types of the 4 GNSS constellations GPS, GLONASS, Galileo, and BeiDou, from the jammer in question. This information must be considered indicative only. The main principle for putting a signal type in the "Test bands/constellation" list for a given jammer or test, is that measurements done by NKOM indicate that the output signal of the jammer covers the center frequency of the given GNSS band(s).
+Specification of jammers can be found in Appendix G. Jammer power levels are based on 2023/2024 measurements. ``Test bands/constellation'' refers to potentially afflicted signal types of the 4 GNSS constellations GPS, GLONASS, Galileo, and BeiDou, from the jammer in question. This information must be considered indicative only. The main principle for putting a signal type in the ``Test bands/constellation'' list for a given jammer or test, is that measurements done by NKOM indicate that the output signal of the jammer covers the center frequency of the given GNSS band(s).
 
 \section*{Tests within this test group}
 
@@ -1067,7 +1067,7 @@ In general, some tests will be done with jammers on top of the car and some with
 
 \subsection*{Additional information}
 
-Specification of jammers can be found in Appendix G. Jammer power levels are based on 2023/2024 measurements. "Test bands/constellation" refers to potentially afflicted signal types of the 4 GNSS constellations GPS, GLONASS, Galileo, and BeiDou, from the jammer in question. This information must be considered indicative only. The main principle for putting a signal type in the "Test bands/constellation" list for a given jammer or test, is that measurements done by NKOM indicate that the output signal of the jammer covers the center frequency of the given GNSS band(s).
+Specification of jammers can be found in Appendix G. Jammer power levels are based on 2023/2024 measurements. ``Test bands/constellation'' refers to potentially afflicted signal types of the 4 GNSS constellations GPS, GLONASS, Galileo, and BeiDou, from the jammer in question. This information must be considered indicative only. The main principle for putting a signal type in the ``Test bands/constellation'' list for a given jammer or test, is that measurements done by NKOM indicate that the output signal of the jammer covers the center frequency of the given GNSS band(s).
 
 \section*{Tests within this test group}
 
@@ -1155,7 +1155,7 @@ The transmitted power will be ramped up and down from a lower to a higher ERP fo
 
 \subsection*{Additional information}
 
-The jammer employed will be "Porcus Major" F8.1, see Appendix G.
+The jammer employed will be ``Porcus Major'' F8.1, see Appendix G.
 
 \section*{Tests within this test group}
 
@@ -1261,7 +1261,7 @@ These tests will have the highest transmission power experienced during the Jamm
 
 \subsection*{Additional information}
 
-The jammer employed will be "Porcus Major" F8.1, see Appendix G.
+The jammer employed will be ``Porcus Major'' F8.1, see Appendix G.
 
 \section*{Tests within this test group}
 
@@ -1313,7 +1313,7 @@ The transmissions will be done at aviation relevant frequencies with varying deg
 
 \subsection*{Additional information}
 
-The jammer employed will be "Porcus Major" F8.1, see Appendix G.
+The jammer employed will be ``Porcus Major'' F8.1, see Appendix G.
 
 \section*{Tests within this test group}
 
@@ -1392,7 +1392,7 @@ The tests will simulate different very common types of unintentional GNSS interf
 
 \subsection*{Additional information}
 
-The jammer employed will be "Porcus Major" F8.1, see Appendix G.
+The jammer employed will be ``Porcus Major'' F8.1, see Appendix G.
 
 \section*{Tests within this test group}
 
@@ -1579,7 +1579,7 @@ All tests will be performed with the jammers placed 1 to 1.5 meters above ground
 
 \subsection*{Additional information}
 
-Specification of jammers can be found in Appendix G. Jammer power levels are based on 2023/2024 measurements. "Test bands/constellation" refers to potentially afflicted signal types of the 4 GNSS constellations GPS, GLONASS, Galileo, and BeiDou, from the jammer in question. This information must be considered indicative only. The main principle for putting a signal type in the "Test bands/constellation" list for a given jammer or test, is that measurements done by NKOM indicate that the output signal of the jammer covers the center frequency of the given GNSS band(s).
+Specification of jammers can be found in Appendix G. Jammer power levels are based on 2023/2024 measurements. ``Test bands/constellation'' refers to potentially afflicted signal types of the 4 GNSS constellations GPS, GLONASS, Galileo, and BeiDou, from the jammer in question. This information must be considered indicative only. The main principle for putting a signal type in the ``Test bands/constellation'' list for a given jammer or test, is that measurements done by NKOM indicate that the output signal of the jammer covers the center frequency of the given GNSS band(s).
 
 \section*{Tests within this test group}
 
@@ -1730,7 +1730,7 @@ All tests will be performed with the NEAT military jammers from Novatel placed 1
 
 \subsection*{Additional information}
 
-Specification of jammers can be found in Appendix G. Jammer power levels are based on 2023/2024 measurements. "Test bands/constellation" refers to potentially afflicted signal types of the 4 GNSS constellations GPS, GLONASS, Galileo, and BeiDou, from the jammer in question. This information must be considered indicative only. The main principle for putting a signal type in the "Test bands/constellation" list for a given jammer or test, is that measurements done by NKOM indicate that the output signal of the jammer covers the center frequency of the given GNSS band(s).
+Specification of jammers can be found in Appendix G. Jammer power levels are based on 2023/2024 measurements. ``Test bands/constellation'' refers to potentially afflicted signal types of the 4 GNSS constellations GPS, GLONASS, Galileo, and BeiDou, from the jammer in question. This information must be considered indicative only. The main principle for putting a signal type in the ``Test bands/constellation'' list for a given jammer or test, is that measurements done by NKOM indicate that the output signal of the jammer covers the center frequency of the given GNSS band(s).
 
 \section*{Tests within this test group}
 
@@ -2125,7 +2125,7 @@ The idea is to test equipment and systems when exposed to false and misleading G
 
 Simulated signals will be transmitted from a stationary antenna. Generated spoofing scenarios will use broadcast satellite ephemeris data. Simulated signals may use one or more constellations and one or more test bands.
 
-Initial positions are either False (e.g. 70 N, 10 E) or True (target location, normally close to the transmitter antenna location). Initial time is either False (e.g. a jump in time/date) or True (less than 100 ns timing error for a receiver at target location). Some test scenarios may be started with jamming (lasting for 5 min, one or several test bands, before the spoofing transmission is activated). Some spoofing scenarios may be accompanied by continuous jamming (one or several test bands). The indicated "Test bands / constellation" refers to which signals are spoofed. 
+Initial positions are either False (e.g. 70 N, 10 E) or True (target location, normally close to the transmitter antenna location). Initial time is either False (e.g. a jump in time/date) or True (less than 100 ns timing error for a receiver at target location). Some test scenarios may be started with jamming (lasting for 5 min, one or several test bands, before the spoofing transmission is activated). Some spoofing scenarios may be accompanied by continuous jamming (one or several test bands). The indicated ``Test bands / constellation'' refers to which signals are spoofed. 
 
 Static scenarios are a fixed position, while dynamic scenarios are a simulated drive around the area. For each dynamic test, the motion is first spoofed to a fixed start position for 5 minutes before the dynamic motion starts. 
 
@@ -2204,7 +2204,7 @@ The idea is to test equipment and systems when exposed to false and misleading G
 Simulated signals will be transmitted from a stationary antenna. Generated spoofing scenarios will use broadcast satellite ephemeris data. Simulated signals may use one or more constellations and one or more signal bands.
 
 Initial positions are True (target location, normally close to the transmitter antenna location). Initial time is True (less than 100 ns timing error for a receiver at target location). Some test scenarios may be started with jamming (lasting for 5 min, one or several test bands, before the spoofing transmission is activated). Some spoofing scenarios may be 
-accompanied by continuous jamming (one or several test bands). The indicated "Test bands / constellation" refers to which signals are spoofed. 
+accompanied by continuous jamming (one or several test bands). The indicated ``Test bands / constellation'' refers to which signals are spoofed. 
 
 Static scenarios are a fixed position, while dynamic scenarios are a simulated drive around the area. For each dynamic test, the motion is first spoofed to a fixed start position for 5 minutes before the dynamic motion starts. 
 
@@ -2365,7 +2365,7 @@ Min: 0.316 W\\Max: 0.316 W\subsubsection*{Test bands/constellation}
 'L1', 'L2', 'L5', 'E1', 'E5a', 'E5b'
 \subsubsection*{Transmitter equipment}
 'S'
-\\\subsection{2.3.12  Flying (route 4) - "drone scenario" GPS L1 C/A only}
+\\\subsection{2.3.12  Flying (route 4) - ``drone scenario'' GPS L1 C/A only}
 
 \textcolor{lightgray}{\noindent\rule[0.5ex]{\linewidth}{1pt} }
 Signals: GPS L1 C/A. 
@@ -2380,7 +2380,7 @@ Min: 0.316 W\\Max: 0.316 W\subsubsection*{Test bands/constellation}
 'L1'
 \subsubsection*{Transmitter equipment}
 'S'
-\\\subsection{2.3.13  Flying (route 4) - "drone scenario"}
+\\\subsection{2.3.13  Flying (route 4) - ``drone scenario''}
 
 \textcolor{lightgray}{\noindent\rule[0.5ex]{\linewidth}{1pt} }
 Signals: GPS L1 C/A, L2C, L5. Galileo E1, E5. 
@@ -2395,7 +2395,7 @@ Min: 0.316 W\\Max: 0.316 W\subsubsection*{Test bands/constellation}
 'L1', 'L2', 'L5', 'E1', 'E5a', 'E5b'
 \subsubsection*{Transmitter equipment}
 'S'
-\\\subsection{2.3.14  Sailing (route 5) - "ship scenario"}
+\\\subsection{2.3.14  Sailing (route 5) - ``ship scenario''}
 
 \textcolor{lightgray}{\noindent\rule[0.5ex]{\linewidth}{1pt} }
 Signals: GPS L1 C/A, L2C, L5. Galileo E1, E5. 
@@ -2410,7 +2410,7 @@ Min: 0.316 W\\Max: 0.316 W\subsubsection*{Test bands/constellation}
 'L1', 'L2', 'L5', 'E1', 'E5a', 'E5b'
 \subsubsection*{Transmitter equipment}
 'S'
-\\\subsection{2.3.15  Flying (route 2) - "helicopter scenario"}
+\\\subsection{2.3.15  Flying (route 2) - ``helicopter scenario''}
 
 \textcolor{lightgray}{\noindent\rule[0.5ex]{\linewidth}{1pt} }
 Signals: GPS L1 C/A, L2C, L5. Galileo E1, E5. 
@@ -2435,7 +2435,7 @@ The idea is to test equipment and systems when exposed to false and misleading G
 
 Simulated signals will be transmitted from a stationary antenna. Generated spoofing scenarios will use satellite ephemerides different from live sky satellites. Simulated signals may use one or more constellations and one or more signal bands. 
 
-Initial positions are True (target location, normally close to the transmitter antenna location). Some test scenarios may be started with jamming (lasting for 5 min, one or several test bands). Some spoofing scenarios may be accompanied by continuous jamming (one or several test bands). The indicated "Test bands / constellation" refers to which signals are spoofed. 
+Initial positions are True (target location, normally close to the transmitter antenna location). Some test scenarios may be started with jamming (lasting for 5 min, one or several test bands). Some spoofing scenarios may be accompanied by continuous jamming (one or several test bands). The indicated ``Test bands / constellation'' refers to which signals are spoofed. 
 
 There will be a small break between each test and a larger break after the test group is over to allow receivers to reacquire fix onto real satellite signals. 
 
@@ -2454,7 +2454,7 @@ Signals: GPS L1 C/A. Galileo E1.
 
 No jamming. 
 
-Fixed spoofed position: 69.27547832, 15.96832496, 35 m hae. Time offset is + 15 minutes (900 seconds), so "into the future". 
+Fixed spoofed position: 69.27547832, 15.96832496, 35 m hae. Time offset is + 15 minutes (900 seconds), so ``into the future''.
 
 The spoofing power will be ramped from -35 dBm to +15 dBm in steps of 5 dB every two minutes.
 \subsubsection*{Power or power range}
@@ -2469,7 +2469,7 @@ Signals: GPS L1 C/A, L2C, L5. Galileo E1, E5.
 
 No jamming. 
 
-Fixed spoofed position: 69.27547832, 15.96832496, 35 m hae. Time offset is + 15 minutes (900 seconds), so "into the future". 
+Fixed spoofed position: 69.27547832, 15.96832496, 35 m hae. Time offset is + 15 minutes (900 seconds), so ``into the future''. 
 
 Spoofing power ramp -35 dBm to +15 dBm in steps of 5 dB every two minutes.
 \subsubsection*{Power or power range}
@@ -2484,7 +2484,7 @@ Signals: GPS L1 C/A, L2C, L5. Galileo E1, E5.
 
 No jamming. 
 
-Fixed spoofed position: 69.27547832, 15.96832496, 35 m hae. Time offset is - 3 minutes (180 seconds), so "back into the past". 
+Fixed spoofed position: 69.27547832, 15.96832496, 35 m hae. Time offset is - 3 minutes (180 seconds), so ``back into the past''.
 
 Spoofing power will start at -20 dBm and be stepped up to 15 dBm in one step after 10 minutes.
 \subsubsection*{Power or power range}
@@ -2652,7 +2652,7 @@ The idea is to test equipment and systems when exposed to false and misleading G
 
 Simulated signals will be transmitted from a stationary antenna. Generated spoofing scenarios will use broadcast satellite ephemeris data. Simulated signals may use one or more constellations and one or more signal bands. 
 
-Initial positions are True (target location, normally close to the transmitter antenna location). Initial time is True (less than 100 ns timing error for a receiver at target location). Some test scenarios may be started with jamming (lasting for 5 min, one or several test bands). Some spoofing scenarios may be accompanied by continuous jamming (one or several test bands). The indicated "Test bands / constellation" refers to which signals are spoofed. 
+Initial positions are True (target location, normally close to the transmitter antenna location). Initial time is True (less than 100 ns timing error for a receiver at target location). Some test scenarios may be started with jamming (lasting for 5 min, one or several test bands). Some spoofing scenarios may be accompanied by continuous jamming (one or several test bands). The indicated ``Test bands / constellation'' refers to which signals are spoofed. 
 
 There will be a short break between each test and a larger break after the test group is over to allow receivers to reacquire fix onto real satellite signals. 
 
@@ -2671,7 +2671,7 @@ Signals: GPS L1 C/A. Galileo E1.
 
 No jamming. 
 
-Fixed spoofed position: 69.27547832, 15.96832496, 35 m hae. Time offset is + 15 minutes (900 seconds), so "into the future". 
+Fixed spoofed position: 69.27547832, 15.96832496, 35 m hae. Time offset is + 15 minutes (900 seconds), so ``into the future''.
 
 The spoofing power will be ramped from -35 dBm to +15 dBm in steps of 5 dB every two minutes.
 \subsubsection*{Power or power range}
@@ -2686,7 +2686,7 @@ Signals: GPS L1 C/A, L2C, L5. Galileo E1, E5.
 
 No jamming. 
 
-Fixed spoofed position: 69.27547832, 15.96832496, 35 m hae. Time offset is + 15 minutes (900 seconds), so "into the future". 
+Fixed spoofed position: 69.27547832, 15.96832496, 35 m hae. Time offset is + 15 minutes (900 seconds), so ``into the future''.
 
 Spoofing power ramp -35 dBm to +15 dBm in steps of 5 dB every two minutes.
 \subsubsection*{Power or power range}
@@ -2701,7 +2701,7 @@ Signals: GPS L1 C/A, L2C, L5. Galileo E1, E5.
 
 No jamming. 
 
-Fixed spoofed position: 69.27547832, 15.96832496, 35 m hae. Time offset is - 3 minutes (180 seconds), so "back into the past". 
+Fixed spoofed position: 69.27547832, 15.96832496, 35 m hae. Time offset is - 3 minutes (180 seconds), so ``back into the past''.
 
 Spoofing power will start at -20 dBm and be stepped up to 15 dBm in one step after 10 minutes.
 \subsubsection*{Power or power range}
@@ -2716,7 +2716,7 @@ Signals: GPS L1 C/A.
 
 No jamming. 
 
-Fixed spoofed position: 69.27547832, 15.96832496, 35 m hae. Time offset is + 15 minutes (900 seconds), so "into the future". 
+Fixed spoofed position: 69.27547832, 15.96832496, 35 m hae. Time offset is + 15 minutes (900 seconds), so ``into the future''. 
 \subsubsection*{Power or power range}
 Min: 3.16e-07 W\\Max: 0.0316 W\subsubsection*{Test bands/constellation}
 'L1'
@@ -2729,7 +2729,7 @@ Signals: Galileo E1.
 
 No jamming. 
 
-Fixed spoofed position: 69.27547832, 15.96832496, 35 m hae. Time offset is + 15 minutes (900 seconds), so "into the future". 
+Fixed spoofed position: 69.27547832, 15.96832496, 35 m hae. Time offset is + 15 minutes (900 seconds), so ``into the future''. 
 \subsubsection*{Power or power range}
 Min: 3.16e-07 W\\Max: 0.0316 W\subsubsection*{Test bands/constellation}
 'E1'
@@ -2742,7 +2742,7 @@ Signals: GPS L1 C/A, L2C, L5. Galileo E1, E5.
 
 No jamming. 
 
-Fixed spoofed position: 69.27547832, 15.96832496, 35 m hae. Time offset is + 15 minutes (900 seconds), so "into the future".
+Fixed spoofed position: 69.27547832, 15.96832496, 35 m hae. Time offset is + 15 minutes (900 seconds), so ``into the future''.
 \subsubsection*{Power or power range}
 Min: 3.16e-07 W\\Max: 0.0316 W\subsubsection*{Test bands/constellation}
 'L1', 'L2', 'L5', 'E1', 'E5a', 'E5b'
@@ -2755,7 +2755,7 @@ Signals: GPS L1 C/A, L2C, L5. Galileo E1, E5.
 
 No jamming. 
 
-Fixed spoofed position: 69.27547832, 15.96832496, 35 m hae. Time offset is - 3 minutes (180 seconds), so "back into the past". 
+Fixed spoofed position: 69.27547832, 15.96832496, 35 m hae. Time offset is - 3 minutes (180 seconds), so ``back into the past''. 
 \subsubsection*{Power or power range}
 Min: 1e-05 W\\Max: 0.0316 W\subsubsection*{Test bands/constellation}
 'L1', 'L2', 'L5', 'E1', 'E5a', 'E5b'
@@ -3082,27 +3082,27 @@ Min: 1e-05 W\\Max: 1e-05 W\subsubsection*{Test bands/constellation}
 'L1', 'L2', 'L5', 'E1', 'E5a', 'E5b'
 \subsubsection*{Transmitter equipment}
 'S'
-\\\subsection{2.5.29  Time offset 15 minutes from real time - "harbour scenario"}
+\\\subsection{2.5.29  Time offset 15 minutes from real time - ``harbour scenario''}
 
 \textcolor{lightgray}{\noindent\rule[0.5ex]{\linewidth}{1pt} }
 Signals: GPS L1 C/A, L2C, L5. Galileo E1, E5. 
 
 No jamming. 
 
-Fixed spoofed position: Bleik harbour. Time offset is + 15 minutes (900 seconds), so "into the future".
+Fixed spoofed position: Bleik harbour. Time offset is + 15 minutes (900 seconds), so ``into the future''.
 \subsubsection*{Power or power range}
 Min: 0.316 W\\Max: 0.316 W\subsubsection*{Test bands/constellation}
 'L1', 'L2', 'L5', 'E1', 'E5a', 'E5b'
 \subsubsection*{Transmitter equipment}
 'S'
-\\\subsection{2.5.30  Time offset 15 minutes from real time - "helicopter scenario"}
+\\\subsection{2.5.30  Time offset 15 minutes from real time - ``helicopter scenario''}
 
 \textcolor{lightgray}{\noindent\rule[0.5ex]{\linewidth}{1pt} }
 Signals: GPS L1 C/A, L2C, L5. Galileo E1, E5. 
 
 No jamming. 
 
-Simulated start position: Over the sea 1 km N (Midnattskjæran) at 200 m hae. Time offset is + 15 minutes (900 seconds), so "into the future".
+Simulated start position: Over the sea 1 km N (Midnattskjæran) at 200 m hae. Time offset is + 15 minutes (900 seconds), so ``into the future''.
 \subsubsection*{Power or power range}
 Min: 1 W\\Max: 1 W\subsubsection*{Test bands/constellation}
 'L1', 'L2', 'L5', 'E1', 'E5a', 'E5b'
@@ -3112,11 +3112,11 @@ Min: 1 W\\Max: 1 W\subsubsection*{Test bands/constellation}
 
 \subsection*{Rationale}
 
-The objective is to simulate a vehicle-borne spoofing device "out in the wild", so that attendees can experience how a mobile spoofing source affects their (stationary or mobile) equipment and systems.
+The objective is to simulate a vehicle-borne spoofing device ``out in the wild'', so that attendees can experience how a mobile spoofing source affects their (stationary or mobile) equipment and systems.
 
 \subsection*{Test description}
 
-A SDR spoofer will be employed in different ways in and around vehicles. The spoofed signals will be on GPS L1 only. All spoofing tests will be combined with jamming on GLONASS G1. Both jamming and spoofing will be done with 10 dBm. The indicated "Test bands / constellation" refers to which signals are spoofed. 
+A SDR spoofer will be employed in different ways in and around vehicles. The spoofed signals will be on GPS L1 only. All spoofing tests will be combined with jamming on GLONASS G1. Both jamming and spoofing will be done with 10 dBm. The indicated ``Test bands / constellation'' refers to which signals are spoofed. 
 
 There will be a break between each test to allow receivers to reacquire fix onto real satellite signals.
 
@@ -3427,7 +3427,7 @@ Min: 0.001 W\\Max: 0.001 W\subsubsection*{Test bands/constellation}
 'L1', 'L2', 'L5', 'E1', 'E5a', 'E5b'
 \subsubsection*{Transmitter equipment}
 'S'
-\\\section{2.8: Stationary SBAS spoofing with "Do Not Use GPS" commands}
+\\\section{2.8: Stationary SBAS spoofing with ``Do Not Use GPS'' commands}
 
 \subsection*{Rationale}
 
@@ -3439,7 +3439,7 @@ The test will only transmit EGNOS signals, that should be as close to real signa
 
 \section*{Tests within this test group}
 
-\subsection{2.8.1  EGNOS with "Do Not Use GPS" commands}
+\subsection{2.8.1  EGNOS with ``Do Not Use GPS'' commands}
 
 \textcolor{lightgray}{\noindent\rule[0.5ex]{\linewidth}{1pt} }
 Signals: EGNOS L1. 
@@ -3569,14 +3569,14 @@ Meaconing is to record live navigation signals and rebroadcast them with higher 
 \subsection*{Test description}
 
 GNSS retransmission of real live sky signals from one receiver, where the goal is that GNSS user equipment calculates a wrong position using real satellite data, only slightly time delayed.
-The test will retransmit on the L1 and L2 bands, where the employed antennas for the receivers RX1 and RX2 have cut-off frequencies at 1562 – 1588 MHz (L1) \& 1216 – 1240 MHz (L2) and 1564 – 1586 MHz (L1) \& 1218 – 1238 MHz (L2), respectively. This means that GPS L1 and L2, Galileo E1, and BeiDou B1C should be visible in the retransmitted data stream, that GLONASS G1 should not be visible, and that B1I signals from some BeiDou satellites might be visible, especially on RX1. There is also a possibility that G2 signals from some GLONASS satellites might be visible. Please note that the filter's frequency cut-offs are not perfect, so some other signals might "leak" through. 
+The test will retransmit on the L1 and L2 bands, where the employed antennas for the receivers RX1 and RX2 have cut-off frequencies at 1562 – 1588 MHz (L1) \& 1216 – 1240 MHz (L2) and 1564 – 1586 MHz (L1) \& 1218 – 1238 MHz (L2), respectively. This means that GPS L1 and L2, Galileo E1, and BeiDou B1C should be visible in the retransmitted data stream, that GLONASS G1 should not be visible, and that B1I signals from some BeiDou satellites might be visible, especially on RX1. There is also a possibility that G2 signals from some GLONASS satellites might be visible. Please note that the filter's frequency cut-offs are not perfect, so some other signals might ``leak'' through. 
 
 The tests are performed with constant transmission power, some with initial jamming and some without. A 10-minute break between each test is planned. 
 The meaconed position is for RX1: (TBD1) and for RX2: (TBD2).
 
 \subsection*{Additional information}
 
-The meaconing setup employed is F1.1 "Porcellus".The jammer employed is F8.1 "Porcus Major", see Appendix G for more information about the equipment. 
+The meaconing setup employed is F1.1 ``Porcellus''.The jammer employed is F8.1 ``Porcus Major'', see Appendix G for more information about the equipment. 
 
 \section*{Tests within this test group}
 
@@ -3634,13 +3634,13 @@ Meaconing is to record live navigation signals and rebroadcast them with higher 
 \subsection*{Test description}
 
 GNSS re-transmission of real live sky signals from one receiver, where the goal is that GNSS user equipment calculates a wrong position using real satellite data, only slightly time delayed.
- The test will re-transmit on the L1 and L2 bands, where the employed antennas for the receivers RX1 and RX2 have cut-off frequencies at 1562 – 1588 MHz (L1) \& 1216 – 1240 MHz (L2) and 1564 – 1586 MHz (L1) \& 1218 – 1238 MHz (L2), respectively. This means that GPS L1 and L2, Galileo E1, and BeiDou B1C should be visible in the retransmitted data stream, that GLONASS G1 should not be visible, and that B1I signals from some BeiDou satellites might be visible, especially on RX1. There is also a possibility that G2 signals from some GLONASS satellites might be visible. Please note that the filter's frequency cut-offs are not perfect, so some other signals might "leak" through. 
+ The test will re-transmit on the L1 and L2 bands, where the employed antennas for the receivers RX1 and RX2 have cut-off frequencies at 1562 – 1588 MHz (L1) \& 1216 – 1240 MHz (L2) and 1564 – 1586 MHz (L1) \& 1218 – 1238 MHz (L2), respectively. This means that GPS L1 and L2, Galileo E1, and BeiDou B1C should be visible in the retransmitted data stream, that GLONASS G1 should not be visible, and that B1I signals from some BeiDou satellites might be visible, especially on RX1. There is also a possibility that G2 signals from some GLONASS satellites might be visible. Please note that the filter's frequency cut-offs are not perfect, so some other signals might ``leak'' through. 
 
 The tests are performed with constant power outputs, some with initial jamming and some without. There is planned a 10-minute break between each test.
 
 \subsection*{Additional information}
 
-The meaconing setup employed is F1.1 "Porcellus".The jammer employed is F8.1 "Porcus Major", see Appendix G for more information about the equipment.
+The meaconing setup employed is F1.1 ``Porcellus''.The jammer employed is F8.1 ``Porcus Major'', see Appendix G for more information about the equipment.
 
 \section*{Tests within this test group}
 
@@ -3716,11 +3716,11 @@ Meaconing is to record live navigation signals and rebroadcast them with higher 
 \subsection*{Test description}
 
 GNSS re-transmission of real live sky signals from one receiver, where the goal is that GNSS user equipment calculates a wrong position using real satellite data, only slightly time delayed.
-The test will re-transmit on the L1 and L2 bands, where the employed antennas for the receivers RX1 and RX2 have cut-off frequencies at 1562 – 1588 MHz (L1) \& 1216 – 1240 MHz (L2) and 1564 – 1586 MHz (L1) \& 1218 – 1238 MHz (L2), respectively. This means that GPS L1 and L2, Galileo E1, and BeiDou B1C should be visible in the retransmitted data stream, that GLONASS G1 should not be visible, and that B1I signals from some BeiDou satellites might be visible, especially on RX1. There is also a possibility that G2 signals from some GLONASS satellites might be visible. Please note that the filter's frequency cut-offs are not perfect, so some other signals might "leak" through.
+The test will re-transmit on the L1 and L2 bands, where the employed antennas for the receivers RX1 and RX2 have cut-off frequencies at 1562 – 1588 MHz (L1) \& 1216 – 1240 MHz (L2) and 1564 – 1586 MHz (L1) \& 1218 – 1238 MHz (L2), respectively. This means that GPS L1 and L2, Galileo E1, and BeiDou B1C should be visible in the retransmitted data stream, that GLONASS G1 should not be visible, and that B1I signals from some BeiDou satellites might be visible, especially on RX1. There is also a possibility that G2 signals from some GLONASS satellites might be visible. Please note that the filter's frequency cut-offs are not perfect, so some other signals might ``leak'' through.
 
 \subsection*{Additional information}
 
-The meaconing setup employed is F1.1 "Porcellus".The jammer employed is F8.1 "Porcus Major", see Appendix G for more information about the equipment.
+The meaconing setup employed is F1.1 ``Porcellus''.The jammer employed is F8.1 ``Porcus Major'', see Appendix G for more information about the equipment.
 
 \section*{Tests within this test group}
 

--- a/Latex/transmissionplan/plan-wednesday.tex
+++ b/Latex/transmissionplan/plan-wednesday.tex
@@ -50,10 +50,10 @@ Start time: & 09:00 & 09:00 & 09:00 \\ \hline
  \vspace{1mm} \footnotesize{\hspace{3mm}Comment: Pre-booking required. Inform staff of required jammer equipment (see Appendix G of test catalog) } \\ 
 \footnotesize{\hspace{3mm}Contact: Jahn Erik Røhme (NPRA) } \\ 
 } \\  
-{13:00} & {\normalsize{\textbf{13:30-13:40 - 2.8.1 \\ EGNOS with "Do Not Use GPS" commands } } \\ 
+{13:00} & {\normalsize{\textbf{13:30-13:40 - 2.8.1 \\ EGNOS with ``Do Not Use GPS'' commands } } \\ 
  \vspace{1mm} \footnotesize{\hspace{3mm}Power: 1W } \\ 
 \footnotesize{\hspace{3mm}Contact: Nicolai Gerrard (NKOM) } \\ 
- \hrulefill \\\normalsize{\textbf{13:45-14:00 - 2.8.1 \\ EGNOS with "Do Not Use GPS" commands } } \\ 
+ \hrulefill \\\normalsize{\textbf{13:45-14:00 - 2.8.1 \\ EGNOS with ``Do Not Use GPS'' commands } } \\ 
  \vspace{1mm} \footnotesize{\hspace{3mm}Power: 1W } \\ 
 \footnotesize{\hspace{3mm}Contact: Nicolai Gerrard (NKOM) } \\ 
 } & {\normalsize{\textbf{13:00-14:00 - 0.2.1 \\ Jamming booking slot } } \\ 
@@ -108,7 +108,7 @@ Start time: & 09:00 & 09:00 & 09:00 \\ \hline
 {17:00} & {\normalsize{\textbf{17:10-17:25 - 2.3.11 \\ Simulated driving (route 1) with initial and continuous jamming. } } \\ 
  \vspace{1mm} \footnotesize{\hspace{3mm}Power: 0.316W } \\ 
 \footnotesize{\hspace{3mm}Contact: Nicolai Gerrard (NKOM) } \\ 
- \hrulefill \\\normalsize{\textbf{17:55-18:05 - 2.3.12 \\ Flying (route 4) - "drone scenario" GPS L1 C/A only } } \\ 
+ \hrulefill \\\normalsize{\textbf{17:55-18:05 - 2.3.12 \\ Flying (route 4) - ``drone scenario'' GPS L1 C/A only } } \\ 
  \vspace{1mm} \footnotesize{\hspace{3mm}Power: 0.316W } \\ 
 \footnotesize{\hspace{3mm}Contact: Nicolai Gerrard (NKOM) } \\ 
 } & {\normalsize{\textbf{17:00-18:00 - 0.2.1 \\ Jamming booking slot } } \\ 
@@ -118,13 +118,13 @@ Start time: & 09:00 & 09:00 & 09:00 \\ \hline
  \vspace{1mm} \footnotesize{\hspace{3mm}Comment: Pre-booking required. Inform staff of required jammer equipment (see Appendix G of test catalog) } \\ 
 \footnotesize{\hspace{3mm}Contact: Jahn Erik Røhme (NPRA) } \\ 
 } \\  
-{18:00} & {\normalsize{\textbf{18:10-18:20 - 2.3.13 \\ Flying (route 4) - "drone scenario" } } \\ 
+{18:00} & {\normalsize{\textbf{18:10-18:20 - 2.3.13 \\ Flying (route 4) - ``drone scenario'' } } \\ 
  \vspace{1mm} \footnotesize{\hspace{3mm}Power: 0.316W } \\ 
 \footnotesize{\hspace{3mm}Contact: Nicolai Gerrard (NKOM) } \\ 
- \hrulefill \\\normalsize{\textbf{18:30-18:40 - 2.3.15 \\ Flying (route 2) - "helicopter scenario" } } \\ 
+ \hrulefill \\\normalsize{\textbf{18:30-18:40 - 2.3.15 \\ Flying (route 2) - ``helicopter scenario'' } } \\ 
  \vspace{1mm} \footnotesize{\hspace{3mm}Power: 0.316W } \\ 
 \footnotesize{\hspace{3mm}Contact: Nicolai Gerrard (NKOM) } \\ 
- \hrulefill \\\normalsize{\textbf{18:45-19:00 - 2.3.15 \\ Flying (route 2) - "helicopter scenario" } } \\ 
+ \hrulefill \\\normalsize{\textbf{18:45-19:00 - 2.3.15 \\ Flying (route 2) - ``helicopter scenario'' } } \\ 
  \vspace{1mm} \footnotesize{\hspace{3mm}Power: 0.316W } \\ 
 \footnotesize{\hspace{3mm}Contact: Nicolai Gerrard (NKOM) } \\ 
 } & {\normalsize{\textbf{18:00-19:00 - 0.2.1 \\ Jamming booking slot } } \\ 


### PR DESCRIPTION
In latex, the correct way to write quotes is two backticks and then two apostrophes (e.g. ``this'') rather than with two double quote symbols (e.g. "not this"). With double quotes, the first pair of quotes will render backwards, as shown below.

![quotes](https://github.com/user-attachments/assets/29f7c21e-991e-4a62-a72e-4837fad1ac61)

This pull request fixes all of the double quotes. The same thing should probably be done with all of the single quoted items (e.g. 'E1'), but I should probably do some real work today. :) 