### PR TITLE
Update dates for tests 2.6.8 and 2.6.9

### DIFF
--- a/plan-thursday-2025-09-18.json
+++ b/plan-thursday-2025-09-18.json
@@ -395,8 +395,8 @@
           "status": ""
         },
         {
-          "start_time": "2025-09-15T12:20:00",
-          "end_time": "2025-09-15T12:35:00",
+          "start_time": "2025-09-18T12:20:00",
+          "end_time": "2025-09-18T12:35:00",
           "test_id": "2.6.8",
           "test_contact": "Jahn Erik Røhme (NPRA)",
           "power_w": 0.001,
@@ -476,8 +476,8 @@
           "status": ""
         },
         {
-          "start_time": "2025-09-15T17:20:00",
-          "end_time": "2025-09-15T17:35:00",
+          "start_time": "2025-09-18T17:20:00",
+          "end_time": "2025-09-18T17:35:00",
           "test_id": "2.6.9",
           "test_contact": "Jahn Erik Røhme (NPRA)",
           "power_w": 0.001,


### PR DESCRIPTION
These two tests are dated on Monday 15th of September, but appear in the Thursday transmission plan file. 